### PR TITLE
feat(ci): Add production target to Docker build

### DIFF
--- a/.woodpecker/build.yaml
+++ b/.woodpecker/build.yaml
@@ -14,6 +14,7 @@ steps:
       repo: techio-dev/bolt.diy
       dockerfile: Dockerfile
       cache: true
+      target: bolt-ai-production
       username:
         from_secret: github-username
       password:


### PR DESCRIPTION
Adds a new `target` parameter to the Docker build step in the
Woodpecker CI configuration. This targets the `bolt-ai-production`
stage of the Dockerfile, which is used to build the production-ready
Docker image.